### PR TITLE
Handle Windows paths in git: URI construction

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -500,7 +500,7 @@ function buildHoverMessage(info: CommitInfo) {
 }
 
 function gitUri(ref: Sha, path: string) {
-  return vscode.Uri.from({ scheme: "git", path, query: JSON.stringify({ ref, path }) });
+  return gitApi.toGitUri(vscode.Uri.file(path), ref)
 }
 
 function getRepo(uri: vscode.Uri) {


### PR DESCRIPTION
This fixes #2 for me and seems like it should be platform independent.

Tested via "Launch Extension" and by `npx @vscode/vsce package` and loading the resulting `.vsix` file.
Tested using VS Code 1.91.1, Git 2.45.2.windows.1, Windows 10 22H2 build 19045.4651.
