### PR TITLE
Proof-of-concept embedded PR link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Turn GitHub and GitLab issue/PR numbers into links ([#11](https://github.com/mk12/vscode-better-git-line-blame/issues/11)). Thanks to [jkjustjoshing](https://github.com/jkjustjoshing) for helping.
+
 ## 0.2.12
 
 - Annotate the line where the active cursor is, not the top line of the selection ([#16](https://github.com/mk12/vscode-better-git-line-blame/issues/16)).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Get [Better Git Line Blame](https://marketplace.visualstudio.com/items?itemName=
 - Optionally shows blame information in the status bar.
 - Caches blame data so annotations are instantaneous.
 - On hover, shows the commit author, date, message, and SHA.
+- Autolinks to issues and PRs on GitHub and GitLab.
 - Includes a "Show diff" link using VS Code's built-in diff viewer.
 - Supports multiple git repositories in the same workspace.
 - Uses `git blame --incremental` to provide blame quickly and incrementally.


### PR DESCRIPTION
I was curious how difficult it would be to implement #11. Here is a VERY rough proof-of-concept. It only works for repos with an `origin` remote set up on github.com with SSH, and there is an `as any` and disabling of an ESLint rule.

Definitely needs some work before merging.